### PR TITLE
add explicit need for git-lfs

### DIFF
--- a/deepspeech.html
+++ b/deepspeech.html
@@ -6,6 +6,7 @@
 <h3>Download DeepSpeech code:</h3>
 
 <pre>
+$ apt-get install git-lfs # Need git large file storage for deepspeech
 $ git clone --depth 1 https://github.com/mozilla/DeepSpeech.git
 </pre>
 


### PR DESCRIPTION
from the orginal docs:

```
Install Git Large File Storage, either manually or through a package like git-lfs if available on your system. Then clone the DeepSpeech repository normally:
```